### PR TITLE
Get rid of advisory locks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,10 @@ Metrics/AbcSize:
   Max: 30
 
 Metrics/MethodLength:
-  Max: 40
+  Max: 45
+
+Metrics/BlockLength:
+  Max: 30
 
 Metrics/ModuleLength:
   Max: 200

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,10 @@
 PATH
   remote: .
   specs:
-    artery (0.8.4)
+    artery (0.8.5)
       multiblock (~> 0.2)
       nats (>= 0.8, < 0.12)
       rails (>= 4.2, < 7.1)
-      with_advisory_lock (>= 4.0, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -71,8 +70,7 @@ GEM
       zeitwerk (~> 2.3)
     ast (2.4.2)
     builder (3.2.4)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
+    childprocess (5.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     diff-lcs (1.3)
@@ -84,12 +82,11 @@ GEM
     factory_girl_rails (4.9.0)
       factory_girl (~> 4.9.0)
       railties (>= 3.0.0)
-    ffi (1.9.25)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    iniparse (1.4.4)
+    iniparse (1.5.0)
     io-wait (0.3.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
@@ -124,9 +121,10 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    overcommit (0.46.0)
-      childprocess (~> 0.6, >= 0.6.3)
+    overcommit (0.62.0)
+      childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
+      rexml (~> 3.2)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
@@ -211,8 +209,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    with_advisory_lock (4.6.0)
-      activerecord (>= 4.2)
     zeitwerk (2.6.11)
 
 PLATFORMS
@@ -227,4 +223,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.3
+   2.4.22

--- a/app/models/concerns/artery/message_model.rb
+++ b/app/models/concerns/artery/message_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Artery
   module MessageModel
     extend ActiveSupport::Concern
@@ -6,7 +8,7 @@ module Artery
     end
 
     module ClassMethods
-      MAX_MESSAGE_AGE = ENV.fetch('ARTERY_MAX_MESSAGE_AGE') { '90' }.to_i.days
+      MAX_MESSAGE_AGE = ENV.fetch('ARTERY_MAX_MESSAGE_AGE', '90').to_i.days
 
       def after_index(model, index)
         raise NotImplementedError
@@ -45,7 +47,7 @@ module Artery
     protected
 
     def send_to_artery
-      Artery.publish route, to_artery.merge( '_previous_index' => previous_index)
+      Artery.publish route, to_artery.merge('_previous_index' => previous_index)
     end
   end
 end

--- a/artery.gemspec
+++ b/artery.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 
 # Maintain your gem's version:
 require 'artery/version'
@@ -22,8 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'multiblock',         '~> 0.2'
-  s.add_dependency 'with_advisory_lock', '>= 4.0', '< 5.0'
+  s.add_dependency 'multiblock', '~> 0.2'
 
   s.add_dependency 'nats',         '>= 0.8', '< 0.12'
   # s.add_dependency 'nats-pure',    '~> 0.5'

--- a/lib/artery.rb
+++ b/lib/artery.rb
@@ -7,7 +7,6 @@ require 'artery/backends/base'
 
 require 'multiblock'
 require 'multiblock_has_block'
-require 'with_advisory_lock'
 
 module Artery
   autoload :Config,        'artery/config'
@@ -42,6 +41,7 @@ module Artery
 
   class << self
     attr_accessor :worker
+
     def handle_signals
       %w[TERM INT].each do |sig|
         trap(sig) do

--- a/lib/artery/no_brainer/message.rb
+++ b/lib/artery/no_brainer/message.rb
@@ -16,7 +16,7 @@ module Artery
       field :data,    type: Hash,   required: true
       field :_index,  type: Integer, index: true
 
-      alias :index :_index
+      alias index _index
 
       after_save :send_to_artery
 
@@ -55,10 +55,8 @@ module Artery
 
       protected
 
-      def lock_on_model
-        ::NoBrainer::Lock.new("#{self.class.table_name}:#{model}").synchronize do
-          yield
-        end
+      def lock_on_model(&block)
+        ::NoBrainer::Lock.new("#{self.class.table_name}:#{model}").synchronize(&block)
       end
 
       def assign_index

--- a/lib/artery/no_brainer/subscription_info.rb
+++ b/lib/artery/no_brainer/subscription_info.rb
@@ -34,7 +34,7 @@ module Artery
       def with_lock
         was_locked = @lock.present?
 
-        if (was_locked) # only 'indexed' messages should lock
+        if was_locked # only 'indexed' messages should lock
           yield
         else
           Artery.logger.debug "WAITING FOR LOCK... [LATEST_INDEX: #{latest_index}]"

--- a/lib/artery/subscription.rb
+++ b/lib/artery/subscription.rb
@@ -49,7 +49,7 @@ module Artery
       info.update! new_data
     end
 
-    def handle(message)
+    def handle(message) # rubocop:disable Metrics/AbcSize
       Artery.logger.debug "GOT MESSAGE: #{message.inspect}"
 
       info.lock_for_message(message) do

--- a/lib/artery/version.rb
+++ b/lib/artery/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Artery
-  VERSION = '0.8.4'
+  VERSION = '0.8.5'
 end


### PR DESCRIPTION
Advisory lock was added to ensure correct sequence of indexes (`_previous_index` and `_index` in published message, that nobody inserted something between them). 

BUT. `_previous_index` is used ONLY in `after_commit` callback, where the sequence is already fixed. So we just can do a query and get the highest index lower than current. And it will always be the same. Before advisory_lock `previous_index` was assigned in `around_create` — and this was the main problem. There is no need to do this.