### PR TITLE
Fix ThreadError deadlock while using DB in parallel fibers on sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    artery (0.10.0)
+    artery (0.10.1)
       multiblock (~> 0.2)
       nats (>= 0.8, < 0.12)
       rails (>= 4.2, < 8)

--- a/lib/artery/subscription/synchronization.rb
+++ b/lib/artery/subscription/synchronization.rb
@@ -82,17 +82,13 @@ module Artery
       def receive_all
         synchronization_in_progress! unless synchronization_in_progress?
 
-        Fiber.new do # all requests insuide must be synchronous
-          while receive_all_once == :continue; end
-        end.resume
+        while receive_all_once == :continue; end
       end
 
       def receive_updates
         synchronization_in_progress!
 
-        Fiber.new do # all requests insuide must be synchronous
-          while receive_updates_once == :continue; end
-        end.resume
+        while receive_updates_once == :continue; end
       end
 
       private

--- a/lib/artery/sync.rb
+++ b/lib/artery/sync.rb
@@ -17,7 +17,10 @@ module Artery
         return
       end
 
-      subscriptions_on_services.values.flatten.uniq.each(&:synchronize!)
+      @sync_fiber = Fiber.new do # all synchroniza tion inside must be synchronous
+        subscriptions_on_services.values.flatten.uniq.each(&:synchronize!)
+      end
+      @sync_fiber.resume
     end
 
     def self.run(subscriptions)

--- a/lib/artery/sync.rb
+++ b/lib/artery/sync.rb
@@ -17,7 +17,7 @@ module Artery
         return
       end
 
-      @sync_fiber = Fiber.new do # all synchroniza tion inside must be synchronous
+      @sync_fiber = Fiber.new do # all synchronization inside must be synchronous
         subscriptions_on_services.values.flatten.uniq.each(&:synchronize!)
       end
       @sync_fiber.resume

--- a/lib/artery/version.rb
+++ b/lib/artery/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Artery
-  VERSION = '0.10.0'
+  VERSION = '0.10.1'
 end

--- a/lib/artery/worker.rb
+++ b/lib/artery/worker.rb
@@ -17,7 +17,7 @@ module Artery
       WorkerHealthzSubscription.new(worker_id, 'worker').subscribe
     end
 
-    def run(services = nil) # rubocop:disable Metrics/AbcSize
+    def run(services = nil)
       services = Array.wrap(services).map(&:to_sym)
       subscriptions_on_services = services.blank? ? Artery.subscriptions : Artery.subscriptions_on(services)
 


### PR DESCRIPTION
## Problem 

If there are several subscriptions, that need to be synchronized: they are running in separate fibers. If syncronization is in EventMachine (in artery-worker), then this situation causes following error (after upgrading to Ruby 3+)
```
/app/vendor/bundle/ruby/3.3.0/gems/activesupport-6.1.7.8/lib/active_support/concurrency/load_interlock_aware_monitor.rb:17:in `enter': deadlock; lock already owned by another fiber belonging to the same thread (ThreadError)
```

## Solution

Make the whole Sync with all subscriptions run in one fiber continuously.